### PR TITLE
Search for device modules also where env says

### DIFF
--- a/OpenScan.cpp
+++ b/OpenScan.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <iterator>
 #include <set>
@@ -63,7 +64,11 @@ MODULE_API void DeleteDevice(MM::Device *device) { delete device; }
 OpenScan::OpenScan()
     : nextAdHocErrorCode_(MIN_ADHOC_ERROR_CODE), oscLSM_(0), acqTemplate_(0),
       sequenceAcquisition_(0), sequenceAcquisitionStopOnOverflow_(false) {
-    const char *paths[] = {".", NULL};
+    const char *paths[] = {
+        ".",
+        std::getenv("MICROMANAGER_PATH"), // Cf. pymmcore-plus
+        NULL,
+    };
     OSc_SetDeviceModuleSearchPaths(paths);
 
     size_t count;

--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,7 @@ mmda = shared_module(
         mmdevice_dep,
     ],
     cpp_args: [
+        '-D_CRT_SECURE_NO_WARNINGS',
         '-DMODULE_EXPORTS',
     ],
 )


### PR DESCRIPTION
In addition to the current directory (works with MMStudio), look for .osdev modules also in the directory given by the environment variable MICROMANAGER_PATH (which also sets where pymmcore-plus find device adapters).